### PR TITLE
build: update project Java version to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,10 @@
         <version>2.2.2.RELEASE</version>
     </parent>
 
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
Update the Maven project configuration to target Java 17.

## Changes
- Added a java.version property set to 17 in pom.xml
- Kept existing dependency and plugin configuration unchanged

## Test Plan
- Verified pom.xml contains the java.version property set to 17 on branch feature/update-java-17
- No runtime tests were executed (configuration-only change)