### PR TITLE
feat: add CRUD APIs for invoice management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,15 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/com/rename/app/controllers/InvoiceController.java
+++ b/src/main/java/com/rename/app/controllers/InvoiceController.java
@@ -1,0 +1,66 @@
+package com.rename.app.controllers;
+
+import com.rename.app.models.Invoice;
+import com.rename.app.services.InvoiceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/invoices")
+public class InvoiceController {
+
+    @Autowired
+    private InvoiceService invoiceService;
+
+    @PostMapping
+    public ResponseEntity<Invoice> createInvoice(@RequestBody Invoice invoice) {
+        Invoice created = invoiceService.createInvoice(invoice);
+        return ResponseEntity.created(URI.create("/api/invoices/" + created.getId())).body(created);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Invoice>> getAllInvoices() {
+        return ResponseEntity.ok(invoiceService.getAllInvoices());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Invoice> getInvoiceById(@PathVariable Long id) {
+        Invoice invoice = invoiceService.getInvoiceById(id);
+        if (invoice == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(invoice);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Invoice> updateInvoice(@PathVariable Long id, @RequestBody Invoice invoice) {
+        Invoice updated = invoiceService.updateInvoice(id, invoice);
+        if (updated == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteInvoice(@PathVariable Long id) {
+        boolean deleted = invoiceService.deleteInvoice(id);
+        if (!deleted) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/rename/app/models/Invoice.java
+++ b/src/main/java/com/rename/app/models/Invoice.java
@@ -1,0 +1,57 @@
+package com.rename.app.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Invoice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String customerName;
+
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    private InvoiceStatus status;
+
+    private LocalDate dueDate;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/rename/app/models/InvoiceStatus.java
+++ b/src/main/java/com/rename/app/models/InvoiceStatus.java
@@ -1,0 +1,9 @@
+package com.rename.app.models;
+
+public enum InvoiceStatus {
+    DRAFT,
+    SENT,
+    PAID,
+    OVERDUE,
+    CANCELLED
+}

--- a/src/main/java/com/rename/app/repositories/InvoiceRepository.java
+++ b/src/main/java/com/rename/app/repositories/InvoiceRepository.java
@@ -1,0 +1,9 @@
+package com.rename.app.repositories;
+
+import com.rename.app.models.Invoice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InvoiceRepository extends JpaRepository<Invoice, Long> {
+}

--- a/src/main/java/com/rename/app/services/InvoiceService.java
+++ b/src/main/java/com/rename/app/services/InvoiceService.java
@@ -1,0 +1,52 @@
+package com.rename.app.services;
+
+import com.rename.app.models.Invoice;
+import com.rename.app.repositories.InvoiceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class InvoiceService {
+
+    @Autowired
+    private InvoiceRepository invoiceRepository;
+
+    public Invoice createInvoice(Invoice invoice) {
+        invoice.setId(null);
+        return invoiceRepository.save(invoice);
+    }
+
+    public List<Invoice> getAllInvoices() {
+        return invoiceRepository.findAll();
+    }
+
+    public Invoice getInvoiceById(Long id) {
+        return invoiceRepository.findById(id).orElse(null);
+    }
+
+    public Invoice updateInvoice(Long id, Invoice invoice) {
+        Invoice existing = getInvoiceById(id);
+        if (existing == null) {
+            return null;
+        }
+
+        existing.setCustomerName(invoice.getCustomerName());
+        existing.setAmount(invoice.getAmount());
+        existing.setStatus(invoice.getStatus());
+        existing.setDueDate(invoice.getDueDate());
+
+        return invoiceRepository.save(existing);
+    }
+
+    public boolean deleteInvoice(Long id) {
+        Invoice existing = getInvoiceById(id);
+        if (existing == null) {
+            return false;
+        }
+
+        invoiceRepository.delete(existing);
+        return true;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 server.port=${PORT:8080}
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:invoicesdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/rename/app/services/InvoiceServiceTest.java
+++ b/src/test/java/com/rename/app/services/InvoiceServiceTest.java
@@ -1,0 +1,67 @@
+package com.rename.app.services;
+
+import com.rename.app.TestNGWithSpringApplication;
+import com.rename.app.models.Invoice;
+import com.rename.app.models.InvoiceStatus;
+import com.rename.app.repositories.InvoiceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+@SpringBootTest(classes = TestNGWithSpringApplication.class)
+public class InvoiceServiceTest extends AbstractTestNGSpringContextTests {
+
+    @Autowired
+    private InvoiceService invoiceService;
+
+    @Autowired
+    private InvoiceRepository invoiceRepository;
+
+    @BeforeMethod
+    public void setup() {
+        invoiceRepository.deleteAll();
+    }
+
+    @Test
+    public void testInvoiceCrudFlow() {
+        Invoice created = invoiceService.createInvoice(Invoice.builder()
+                .customerName("Acme Corp")
+                .amount(new BigDecimal("99.50"))
+                .status(InvoiceStatus.DRAFT)
+                .dueDate(LocalDate.of(2026, 3, 1))
+                .build());
+
+        assertNotNull(created.getId());
+        assertEquals(invoiceService.getAllInvoices().size(), 1);
+
+        Invoice fetched = invoiceService.getInvoiceById(created.getId());
+        assertNotNull(fetched);
+        assertEquals(fetched.getCustomerName(), "Acme Corp");
+
+        Invoice updated = invoiceService.updateInvoice(created.getId(), Invoice.builder()
+                .customerName("Acme Corp Updated")
+                .amount(new BigDecimal("120.00"))
+                .status(InvoiceStatus.SENT)
+                .dueDate(LocalDate.of(2026, 3, 15))
+                .build());
+
+        assertNotNull(updated);
+        assertEquals(updated.getStatus(), InvoiceStatus.SENT);
+        assertEquals(updated.getCustomerName(), "Acme Corp Updated");
+
+        boolean deleted = invoiceService.deleteInvoice(created.getId());
+        assertTrue(deleted);
+        assertEquals(invoiceService.getAllInvoices().size(), 0);
+        assertNull(invoiceService.getInvoiceById(created.getId()));
+    }
+}


### PR DESCRIPTION
## Summary
Add invoice CRUD APIs backed by Spring Data JPA with an in-memory H2 database.

## Changes
- Added `Invoice` entity and `InvoiceStatus` enum in `models`
- Added `InvoiceRepository` for persistence
- Added `InvoiceService` with create/read/update/delete operations
- Added `InvoiceController` with endpoints under `/api/invoices`
- Updated `pom.xml` with `spring-boot-starter-data-jpa` and `h2` dependencies
- Updated `application.properties` with H2 datasource + JPA configuration
- Added `InvoiceServiceTest` covering create, read, update, and delete flow

## Test Plan
- Added `InvoiceServiceTest` to validate end-to-end service CRUD behavior against H2
- Verified controller/service/repository wiring and endpoint mappings in code review
- Automated test execution was not run in this environment (remote API-only workflow)